### PR TITLE
changed array size constants to public

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -96,9 +96,9 @@ public static class Constants
     #region Array size
 
     internal const uint CHATLOG_ARRAY_SIZE = 1000;
-    internal const uint ENTITY_ARRAY_SIZE = 100;
-    internal const uint PARTY_MEMBER_ARRAY_SIZE = 8;
-    internal const uint GATHERING_ARRAY_SIZE = 40;
+    public const uint ENTITY_ARRAY_SIZE = 100;
+    public const uint PARTY_MEMBER_ARRAY_SIZE = 8;
+    public const uint GATHERING_ARRAY_SIZE = 40;
 
     #endregion
 

--- a/ResourceParser.cs
+++ b/ResourceParser.cs
@@ -20,6 +20,9 @@ namespace ffxivlib
         /// <returns>Yields next element</returns>
         private static IEnumerable<XElement> StreamElements(string fileName, string elementName)
         {
+            if (!File.Exists(fileName))
+                yield break;
+
             using (var sr = new StreamReader(fileName, Encoding.GetEncoding("UTF-8")))
                 {
                     using (var rdr = XmlTextReader.Create(sr))


### PR DESCRIPTION
FFXIVLIB.GetEntityById() suggests using Constants.ENTITY_ARRAY_SIZE, but the constant was marked as internal.
